### PR TITLE
Fix SyntaxError: cannot mix bytes and nonbytes literals

### DIFF
--- a/unlocker.py
+++ b/unlocker.py
@@ -52,8 +52,7 @@ if sys.version_info < (2, 7):
     sys.exit(1)
 
 # Setup imports depending on whether IronPython or CPython
-if sys.platform == 'win32' \
-        or sys.platform == 'cli':
+if sys.platform in ('cli', 'win32'):
     # noinspection PyUnresolvedReferences
     from _winreg import *
 
@@ -302,8 +301,8 @@ def patchbase(name):
 
     # Entry to search for in GOS table
     # Should work for 12 & 14 of Workstation...
-    darwin = b'\x10\x00\x00\x00\x10\x00\x00\x00\x02\x00\x00\x00\x00\x00\x00\x00' \
-             '\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00'
+    darwin = (b'\x10\x00\x00\x00\x10\x00\x00\x00\x02\x00\x00\x00\x00\x00\x00\x00'
+              b'\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00')
 
     # Read file into string variable
     base = f.read()


### PR DESCRIPTION
[flake8](http://flake8.pycqa.org) testing of https://github.com/DrDonk/unlocker on Python 3.7.1

$ __flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics__
```
./unlocker.py:305:13: E999 SyntaxError: cannot mix bytes and nonbytes literals
    darwin = b'\x10\x00\x00\x00\x10\x00\x00\x00\x02\x00\x00\x00\x00\x00\x00\x00' \
            ^
1     E999 SyntaxError: cannot mix bytes and nonbytes literals
1
```
__E901,E999,F821,F822,F823__ are the "_showstopper_" [flake8](http://flake8.pycqa.org) issues that can halt the runtime with a SyntaxError, NameError, etc. These 5 are different from most other flake8 issues which are merely "style violations" -- useful for readability but they do not effect runtime safety.
* F821: undefined name `name`
* F822: undefined name `name` in `__all__`
* F823: local variable name referenced before assignment
* E901: SyntaxError or IndentationError
* E999: SyntaxError -- failed to compile a file into an Abstract Syntax Tree