### PR TITLE
Get tools ISO from core if get from package fails, and try older release if failure to get current.

### DIFF
--- a/gettools.py
+++ b/gettools.py
@@ -150,6 +150,49 @@ def gettoolsfrompackage(urlrelease, dest):
     os.remove(convertpath(dest + '/tools/com.vmware.fusion.tools.darwinPre15.zip'))
 
 
+def gettoolsfromcore(urlrelease, dest):
+    # Re-create the tools folder
+    shutil.rmtree(dest + '/tools', True)
+    os.mkdir(dest + '/tools')
+
+    # Open the release page
+    # And build file URL
+    response = urlopen(urlrelease)
+    html = response.read()
+    parser = CDSParser()
+    parser.feed(str(html))
+    urlcore = urlrelease + parser.HTMLDATA[-1] + '/core/com.vmware.fusion.zip.tar'
+    parser.clean()
+
+    # Download the darwin.iso tgz file
+    print('Retrieving Darwin tools from: ' + urlcore)
+    urlretrieve(urlcore, convertpath(dest + '/tools/com.vmware.fusion.zip.tar'))
+
+    # Extract the tar to zip
+    tar = tarfile.open(convertpath(dest + '/tools/com.vmware.fusion.zip.tar'), 'r')
+    tar.extract('com.vmware.fusion.zip', path=convertpath(dest + '/tools/'))
+    tar.close()
+
+    # Extract the iso files from zip
+    cdszip = zipfile.ZipFile(convertpath(dest + '/tools/com.vmware.fusion.zip'), 'r')
+    payloadpath = 'VMware Fusion.app/Contents/Library/isoimages'
+    cdszip.extract('payload/' + payloadpath + '/darwin.iso', path=convertpath(dest + '/tools/'))
+    cdszip.extract('payload/' + payloadpath + '/darwinPre15.iso', path=convertpath(dest + '/tools/'))
+    # TODO: Can we obtain the iso sig files from somewhere?
+    cdszip.close()
+
+    # Move the iso and sig files to tools folder
+    shutil.move(convertpath(dest + '/tools/payload/' + payloadpath + '/darwin.iso'),
+                convertpath(dest + '/tools/darwin.iso'))
+    shutil.move(convertpath(dest + '/tools/payload/' + payloadpath + '/darwinPre15.iso'),
+                convertpath(dest + '/tools/darwinPre15.iso'))
+
+    # Cleanup working files and folders
+    shutil.rmtree(convertpath(dest + '/tools/payload'), True)
+    os.remove(convertpath(dest + '/tools/com.vmware.fusion.zip.tar'))
+    os.remove(convertpath(dest + '/tools/com.vmware.fusion.zip'))
+
+
 def main():
     # Check minimal Python version is 2.7
     if sys.version_info < (2, 7):
@@ -166,6 +209,8 @@ def main():
     # Attempt to obtain tools from the latest release first
     for release in releaselist:
         urlrelease = urlbase + release + '/'
+
+        # Try obtaining tools from release package
         try:
             gettoolsfrompackage(urlrelease, dest)
             print('Darwin tools obtained from package release ' + release)
@@ -177,6 +222,20 @@ def main():
             print('Could not obtain tools package for release ' + release)
         except:
             print('Error obtaining tools package for release ' + release)
+
+        # Failing that, try obtaining tools from release core
+        try:
+            print('Much slower, but try to obtain tools from release core.')
+            gettoolsfromcore(urlrelease, dest)
+            print('Darwin tools obtained from core release ' + release)
+            if releaselist.index(release) != 0:
+                print('This is NOT the latest!! Latest release is ' + releaselist[0])
+            # Done
+            break
+        except tarfile.ReadError:
+            print('Could not obtain tools core for release ' + release)
+        except:
+            print('Error obtaining tools core for release ' + release)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
My suggested updates to gettools.py given the recent apparent change from VMware in release 11.5.0.  Changes are minimal and hopefully in-keeping with your design.  Feel free to use as-is, partially, or modify as desired.  Thank you for providing this package!

Summary:

As of release 11.5.0 it appears that VMware no longer supplies the release package which contained the ISO files, but instead has placed the ISO files inside the core VMware Fusion.app.

Get tools now tries to obtain an older release if an error occurs obtaining the latest release.
A list of releases is obtained first, and iteration from newest to oldest release continues if an error occurs obtaining tools for the current release.

Get tools now tries to obtain ISO files from the core VMware Fusion.app release if the original package get tools attempt fails.
TODO: When getting tools from core, is it possible to obtain the SIG files?
If both package and core get tool attempts fail for the latest release, iteration continues to the previous release.

TODO:
- Update gettools.exe
- Update readme.txt version history
- Update needed to unlocker.py as it does not seem to work correctly after the VMware 15.5 update
