### PR TITLE
Update gettools.py

### DIFF
--- a/gettools.py
+++ b/gettools.py
@@ -135,6 +135,8 @@ def main():
 	try:
 		# Try to get tools from packages folder
 		urlretrieve(urlpost15, convertpath(dest + '/tools/com.vmware.fusion.tools.darwin.zip.tar'))
+		# Check downloaded file
+		tar = tarfile.open(convertpath(dest + '/tools/com.vmware.fusion.tools.darwin.zip.tar'), 'r')
 
 	except:
 		# No tools found, get em from the core tar


### PR DESCRIPTION
Quick fix for this error:
Get macOS VMware Tools 3.0.2
===============================
(c) Dave Parsons 2015-18
Getting VMware Tools...
Trying to get tools from the packages folder...
Retrieving Darwin tools from: http://softwareupdate.vmware.com/cds/vmw-desktop/fusion/11.5.1/15018442/packages/com.vmware.fusion.tools.darwin.zip.tar
Traceback (most recent call last):
  File "gettools.py", line 227, in <module>
    main()
  File "gettools.py", line 181, in main
    tar = tarfile.open(convertpath(dest + '/tools/com.vmware.fusion.tools.darwin.zip.tar'), 'r')
  File "/usr/lib/python2.7/tarfile.py", line 1680, in open
    raise ReadError("file could not be opened successfully")
tarfile.ReadError: file could not be opened successfully