### PR TITLE
Fix typo

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -55,7 +55,7 @@ popd
 
 cp -v LICENSE ./build
 cp -v *.md ./build
-cp -v ./cpuid/linux/cpuid ./buildlinux/cpuid
+cp -v ./cpuid/linux/cpuid ./build/linux/cpuid
 cp -v ./cpuid/windows/cpuid.exe ./build/windows/cpuid.exe
 cp -vr ./iso ./build
 cp -vr ./templates ./build


### PR DESCRIPTION
This fixes a typo which means that the main build script fails to copy one of the binaries into the `build` folder