### PR TITLE
Synchronize the functionality of build.sh to build.cmd.

### DIFF
--- a/build.cmd
+++ b/build.cmd
@@ -1,14 +1,19 @@
 @echo off
 
-echo Building release executables
-if [%1]==[] (
-  echo Product version not found: x.y.z (e.g. 1.2.3)
-  exit /b 1
-)
+REM Read current version
+set /p VERSION=<VERSION
+echo package vmwpatch > .\vmwpatch\version.go
+echo const VERSION = "%VERSION%" >> .\vmwpatch\version.go
+
+echo Building release executables - %VERSION%
+
+if not exist .\build\ISO mkdir .\build\ISO
+if not exist .\build\linux mkdir .\build\linux
+if not exist .\build\windows mkdir .\build\windows
 
 pushd .\commands\check
 echo Building check
-go-winres make --arch amd64 --product-version %1 --file-version %1
+go-winres make --arch amd64 --product-version %VERSION% --file-version %VERSION%
 set GOOS=windows
 set GOARCH=amd64
 go build -o ..\..\build\windows\check.exe
@@ -20,7 +25,7 @@ popd
 
 pushd .\commands\relock
 echo Building relock
-go-winres make --arch amd64 --product-version %1 --file-version %1
+go-winres make --arch amd64 --product-version %VERSION% --file-version %VERSION%
 set GOOS=windows
 set GOARCH=amd64
 go build -o ..\..\build\windows\relock.exe
@@ -32,7 +37,7 @@ popd
 
 pushd .\commands\dumpsmc
 echo Building dumpsmc
-go-winres make --arch amd64 --product-version %1 --file-version %1
+go-winres make --arch amd64 --product-version %VERSION% --file-version %VERSION%
 set GOOS=windows
 set GOARCH=amd64
 go build -o ..\..\build\windows\dumpsmc.exe
@@ -44,19 +49,19 @@ popd
 
 pushd .\commands\unlock
 echo Building unlock
-go-winres make --arch amd64 --product-version %1 --file-version %1
+go-winres make --arch amd64 --product-version %VERSION% --file-version %VERSION%
 set GOOS=windows
 set GOARCH=amd64
-go build -o ..\..\dist\windows\unlock.exe
+go build -o ..\..\build\windows\unlock.exe
 set GOOS=linux
 set GOARCH=amd64
-go build -o ..\..\dist\linux\unlock
+go build -o ..\..\build\linux\unlock
 del /q rsrc_windows_amd64.syso
 popd
 
 pushd .\commands\hostcaps
 echo Building hostcaps
-go-winres make --arch amd64 --product-version %1 --file-version %1
+go-winres make --arch amd64 --product-version %VERSION% --file-version %VERSION%
 set GOOS=windows
 set GOARCH=amd64
 go build -o ..\..\build\windows\hostcaps.exe
@@ -68,7 +73,6 @@ popd
 
 xcopy /R /Y LICENSE .\build\
 xcopy /R /Y *.md .\build\
-xcopy /R /Y cpuid\linux\cpuid .\build\linux\cpuid
-xcopy /R /Y cpuid\windows\cpuid.exe .\build\windows\cpuid.exe
-xcopy /E /F /I /R /Y ISO .\build\ISO
-xcopy /E /F /I /R /Y ISO .\'dist\templates
+xcopy /R /Y cpuid\linux\cpuid .\build\linux\
+xcopy /R /Y cpuid\windows\cpuid.exe .\build\windows\
+xcopy /E /F /I /R /Y ISO .\build\ISO\


### PR DESCRIPTION
Removing `build.cmd` and `clean.cmd` might be another option to reduce maintenance costs, but that would increase build dependencies on Windows.